### PR TITLE
Fix mobile canvas rendering and improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,13 +16,11 @@
       /* Fallback layout CSS for GitHub Pages: ensures mobile ordering/sticky
          even if Tailwind Play CDN misses dynamic classes at first paint. */
       .app-layout { display: grid; grid-template-columns: 1fr; gap: 16px; }
+      @media (min-width: 640px) { .app-layout { gap: 24px; } }
       @media (min-width: 1024px) {
         .app-layout { grid-template-columns: 1fr 1fr; }
-        .app-visual { order: 2; }
+        .app-visual { order: 2; position: sticky; top: 8px; z-index: 10; }
         .app-controls { order: 1; }
-      }
-      @media (max-width: 1023.98px) {
-        .app-visual { position: sticky; top: 8px; z-index: 10; }
       }
     </style>
   </head>

--- a/src/Visualization.jsx
+++ b/src/Visualization.jsx
@@ -1,11 +1,15 @@
 function Visualization({ canvasRef }) {
   return (
-    <Motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-4 sm:p-6 shadow-xl flex flex-col self-start sticky top-2 z-10 lg:static">
+    <Motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-4 sm:p-6 shadow-xl flex flex-col self-start lg:sticky lg:top-2 lg:z-10">
       <div className="flex items-center justify-between gap-4">
         <h2 className="text-base sm:text-lg font-semibold">Visualization</h2>
       </div>
       <div className="mt-3 rounded-xl overflow-hidden border border-white/10">
-        <canvas ref={canvasRef} className="block w-full h-auto" style={{ display: 'block', width: '100%', height: 'auto' }} />
+        <canvas
+          ref={canvasRef}
+          className="block w-full h-auto"
+          style={{ display: 'block', width: '100%', height: 'auto', transform: 'translateZ(0)' }}
+        />
       </div>
 
       {/* Color Key */}

--- a/src/useCanvasDraw.js
+++ b/src/useCanvasDraw.js
@@ -33,125 +33,133 @@ function useCanvasDraw(perSide, barWeight) {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
 
-    // Use a larger drawing buffer for crisper scaling and full-bar view
-    const W = (canvas.width = 1800);
-    const H = (canvas.height = 560);
+    // Force a new frame on mobile Safari to avoid stale rendering
+    canvas.style.transform = 'translateZ(0)';
 
-    // Dark gradient background (original style)
-    ctx.fillStyle = "#0b1220";
-    ctx.fillRect(0, 0, W, H);
-    const grad = ctx.createLinearGradient(0, 0, 0, H);
-    grad.addColorStop(0, "#0b1220");
-    grad.addColorStop(1, "#111827");
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, W, H);
+    const draw = () => {
+      // Use a larger drawing buffer for crisper scaling and full-bar view
+      const W = (canvas.width = 1800);
+      const H = (canvas.height = 560);
 
-    const centerY = H / 2;
-    const sleeveLength = 380;
-    const barLength = W * 0.86;
-    const barX = (W - barLength) / 2;
-    const barH = 30;
+      // Dark gradient background (original style)
+      ctx.fillStyle = "#0b1220";
+      ctx.fillRect(0, 0, W, H);
+      const grad = ctx.createLinearGradient(0, 0, 0, H);
+      grad.addColorStop(0, "#0b1220");
+      grad.addColorStop(1, "#111827");
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, W, H);
 
-    // Horizontal bar and knurl
-    ctx.fillStyle = "#9ca3af";
-    ctx.fillRect(barX, centerY - barH / 2, barLength, barH);
-    ctx.fillStyle = "#6b7280";
-    for (let x = barX + 40; x < barX + barLength - 40; x += 10) ctx.fillRect(x, centerY - 4, 3, 8);
+      const centerY = H / 2;
+      const sleeveLength = 380;
+      const barLength = W * 0.86;
+      const barX = (W - barLength) / 2;
+      const barH = 30;
 
-    // Sleeves
-    const leftSleeveStart = barX + 30;
-    const rightSleeveEnd = barX + barLength - 30;
-    ctx.fillStyle = "#d1d5db";
-    ctx.fillRect(leftSleeveStart, centerY - 24, sleeveLength, 48);
-    ctx.fillRect(rightSleeveEnd - sleeveLength, centerY - 24, sleeveLength, 48);
+      // Horizontal bar and knurl
+      ctx.fillStyle = "#9ca3af";
+      ctx.fillRect(barX, centerY - barH / 2, barLength, barH);
+      ctx.fillStyle = "#6b7280";
+      for (let x = barX + 40; x < barX + barLength - 40; x += 10) ctx.fillRect(x, centerY - 4, 3, 8);
 
-    const sideSizes = Object.keys(perSide).map(Number).sort((a, b) => a - b);
-    // Base gap for plate separation (original feel)
-    const baseGap = 28;
+      // Sleeves
+      const leftSleeveStart = barX + 30;
+      const rightSleeveEnd = barX + barLength - 30;
+      ctx.fillStyle = "#d1d5db";
+      ctx.fillRect(leftSleeveStart, centerY - 24, sleeveLength, 48);
+      ctx.fillRect(rightSleeveEnd - sleeveLength, centerY - 24, sleeveLength, 48);
 
-    const drawSide = (isLeft) => {
-      let accumulated = 0;
-      sideSizes.forEach((size) => {
-        const count = perSide[size] || 0;
-        for (let i = 0; i < count; i++) {
-          const idx = DEFAULT_PLATES.indexOf(size);
-          const color = COLORS[(idx >= 0 ? idx : 0) % COLORS.length];
-          const thickness = Math.max(16, Math.min(56, size));
-          const height = 220 + Math.min(150, size * 4);
-          const y = centerY - height / 2;
-          const extraGap = size <= 2.5 ? 22 : size <= 5 ? 18 : size <= 10 ? 14 : size <= 25 ? 10 : 6;
-          const gap = baseGap + extraGap;
-          const x = isLeft ? leftSleeveStart + 8 + accumulated : rightSleeveEnd - 8 - accumulated - thickness;
+      const sideSizes = Object.keys(perSide).map(Number).sort((a, b) => a - b);
+      // Base gap for plate separation (original feel)
+      const baseGap = 28;
 
-          // Plate body with subtle inner shadow and outer stroke to separate plates
-          ctx.fillStyle = color;
-          ctx.fillRect(x, y, thickness, height);
-          ctx.fillStyle = "rgba(0,0,0,0.22)";
-          ctx.fillRect(x + 3, y + 10, thickness - 6, height - 20);
-          ctx.lineWidth = 2;
-          ctx.strokeStyle = "rgba(255,255,255,0.35)";
-          ctx.strokeRect(x + 0.5, y + 0.5, thickness - 1, height - 1);
+      const drawSide = (isLeft) => {
+        let accumulated = 0;
+        sideSizes.forEach((size) => {
+          const count = perSide[size] || 0;
+          for (let i = 0; i < count; i++) {
+            const idx = DEFAULT_PLATES.indexOf(size);
+            const color = COLORS[(idx >= 0 ? idx : 0) % COLORS.length];
+            const thickness = Math.max(16, Math.min(56, size));
+            const height = 220 + Math.min(150, size * 4);
+            const y = centerY - height / 2;
+            const extraGap = size <= 2.5 ? 22 : size <= 5 ? 18 : size <= 10 ? 14 : size <= 25 ? 10 : 6;
+            const gap = baseGap + extraGap;
+            const x = isLeft ? leftSleeveStart + 8 + accumulated : rightSleeveEnd - 8 - accumulated - thickness;
 
-          // Label centered on the plate with auto-contrast and dynamic size
-          const label = String(size);
-          const minFs = 28, maxFs = 46;
-          const t = Math.max(0, Math.min(1, (height - 220) / 150));
-          const fs = Math.round(minFs + (maxFs - minFs) * t);
-          ctx.font = `900 ${fs}px ui-sans-serif, system-ui, -apple-system`;
-          ctx.textAlign = "center";
-          ctx.textBaseline = "middle";
-          const cx = x + thickness / 2;
-          const cy = y + height / 2;
+            // Plate body with subtle inner shadow and outer stroke to separate plates
+            ctx.fillStyle = color;
+            ctx.fillRect(x, y, thickness, height);
+            ctx.fillStyle = "rgba(0,0,0,0.22)";
+            ctx.fillRect(x + 3, y + 10, thickness - 6, height - 20);
+            ctx.lineWidth = 2;
+            ctx.strokeStyle = "rgba(255,255,255,0.35)";
+            ctx.strokeRect(x + 0.5, y + 0.5, thickness - 1, height - 1);
 
-          // Auto-contrast selection based on plate brightness
-          const rgb = hexToRgb(color);
-          const effectiveLuma = relLuma(rgb) * 0.65; // inner shadow makes plate darker
-          const useDarkText = effectiveLuma > 0.55;
-          const textFill = useDarkText ? "#0b0f19" : "#ffffff";
-          const outline = useDarkText ? "rgba(255,255,255,0.98)" : "rgba(0,0,0,0.92)";
-          ctx.lineJoin = "round";
-          ctx.miterLimit = 2;
-          let lw = Math.max(6, Math.round(fs / 3));
+            // Label centered on the plate with auto-contrast and dynamic size
+            const label = String(size);
+            const minFs = 28, maxFs = 46;
+            const t = Math.max(0, Math.min(1, (height - 220) / 150));
+            const fs = Math.round(minFs + (maxFs - minFs) * t);
+            ctx.font = `900 ${fs}px ui-sans-serif, system-ui, -apple-system`;
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            const cx = x + thickness / 2;
+            const cy = y + height / 2;
 
-          // For very thin plates (e.g., 5 lb and 2.5 lb), add a compact
-          // high-contrast badge behind the text to boost legibility.
-          if (thickness <= 24) {
-            const padX = 8;
-            const badgeW = Math.max(thickness + padX * 2, fs * 1.2);
-            const badgeH = Math.round(fs * 1.05);
-            const bx = cx - badgeW / 2;
-            const by = cy - badgeH / 2;
-            ctx.save();
-            rr(ctx, bx, by, badgeW, badgeH, 8);
-            ctx.fillStyle = useDarkText ? "rgba(255,255,255,0.9)" : "rgba(0,0,0,0.7)";
-            ctx.fill();
-            ctx.restore();
-            lw = Math.max(lw, 4);
+            // Auto-contrast selection based on plate brightness
+            const rgb = hexToRgb(color);
+            const effectiveLuma = relLuma(rgb) * 0.65; // inner shadow makes plate darker
+            const useDarkText = effectiveLuma > 0.55;
+            const textFill = useDarkText ? "#0b0f19" : "#ffffff";
+            const outline = useDarkText ? "rgba(255,255,255,0.98)" : "rgba(0,0,0,0.92)";
+            ctx.lineJoin = "round";
+            ctx.miterLimit = 2;
+            let lw = Math.max(6, Math.round(fs / 3));
+
+            // For very thin plates (e.g., 5 lb and 2.5 lb), add a compact
+            // high-contrast badge behind the text to boost legibility.
+            if (thickness <= 24) {
+              const padX = 8;
+              const badgeW = Math.max(thickness + padX * 2, fs * 1.2);
+              const badgeH = Math.round(fs * 1.05);
+              const bx = cx - badgeW / 2;
+              const by = cy - badgeH / 2;
+              ctx.save();
+              rr(ctx, bx, by, badgeW, badgeH, 8);
+              ctx.fillStyle = useDarkText ? "rgba(255,255,255,0.9)" : "rgba(0,0,0,0.7)";
+              ctx.fill();
+              ctx.restore();
+              lw = Math.max(lw, 4);
+            }
+
+            ctx.lineWidth = lw;
+            ctx.strokeStyle = outline;
+            ctx.strokeText(label, cx, cy + 1);
+            ctx.fillStyle = textFill;
+            ctx.fillText(label, cx, cy + 1);
+
+            accumulated += thickness + gap;
           }
+        });
 
-          ctx.lineWidth = lw;
-          ctx.strokeStyle = outline;
-          ctx.strokeText(label, cx, cy + 1);
-          ctx.fillStyle = textFill;
-          ctx.fillText(label, cx, cy + 1);
+        // Collars at the ends of the plates
+        const collarW = 18;
+        const collarH = 240;
+        const cx = isLeft ? leftSleeveStart + accumulated + 8 : rightSleeveEnd - accumulated - 8 - collarW;
+        const cy = centerY - collarH / 2;
+        ctx.fillStyle = "#e5e7eb";
+        ctx.fillRect(cx, cy, collarW, collarH);
+      };
 
-          accumulated += thickness + gap;
-        }
-      });
+      drawSide(true);
+      drawSide(false);
 
-      // Collars at the ends of the plates
-      const collarW = 18;
-      const collarH = 240;
-      const cx = isLeft ? leftSleeveStart + accumulated + 8 : rightSleeveEnd - accumulated - 8 - collarW;
-      const cy = centerY - collarH / 2;
-      ctx.fillStyle = "#e5e7eb";
-      ctx.fillRect(cx, cy, collarW, collarH);
+      // No top-left bar label
     };
 
-    drawSide(true);
-    drawSide(false);
-
-    // No top-left bar label
+    const raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
   }, [perSide, barWeight]);
 
   return canvasRef;


### PR DESCRIPTION
## Summary
- ensure canvas redraws promptly on mobile with requestAnimationFrame and forced transform
- adjust visualization styles and fallback CSS for responsive, non-sticky mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afbd3c90d48326b52bbbd02a071a3b