### PR TITLE
Unregister service workers after PWA revert

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,25 @@
       })();
     </script>
 
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .getRegistrations()
+          .then(function (registrations) {
+            registrations.forEach(function (registration) {
+              registration.unregister();
+            });
+          });
+      }
+      if (window.caches) {
+        caches.keys().then(function (keys) {
+          keys.forEach(function (key) {
+            caches.delete(key);
+          });
+        });
+      }
+    </script>
+
     <script type="text/babel" data-presets="env,react" src="src/utils.js"></script>
     <script type="text/babel" data-presets="env,react" src="src/useCanvasDraw.js"></script>
     <script type="text/babel" data-presets="env,react" src="src/Controls.jsx"></script>


### PR DESCRIPTION
## Summary
- Unregister existing service worker and clear caches after reverting PWA support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b058e9053c83268d2e675ca5e8fa17