### PR TITLE
fix: scope cache cleanup to app-specific prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,14 @@
       }
       if (window.caches) {
         caches.keys().then(function (keys) {
-          keys.forEach(function (key) {
-            caches.delete(key);
-          });
+          keys
+            // Only clear caches created by this app
+            .filter(function (key) {
+              return key.startsWith('barbell-calculator');
+            })
+            .forEach(function (key) {
+              caches.delete(key);
+            });
         });
       }
     </script>


### PR DESCRIPTION
## Summary
- limit cache clearing to keys starting with `barbell-calculator`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05a3c0a84832693b24e7ff6a92ec2